### PR TITLE
fix: keep tweaking dialog reappears on CSS change after timer ends

### DIFF
--- a/src/components/ChallengePlayer.tsx
+++ b/src/components/ChallengePlayer.tsx
@@ -81,7 +81,7 @@ export default function ChallengePlayer({ challenge, allDates }: ChallengePlayer
   const handleCssChange = useCallback((css: string) => {
     setUserCss(css);
     userCssRef.current = css;
-    if (phaseRef.current !== 'playing') {
+    if (phaseRef.current === 'idle') {
       setPhase('playing');
       phaseRef.current = 'playing';
     }

--- a/src/components/TailwindPlayer.tsx
+++ b/src/components/TailwindPlayer.tsx
@@ -79,7 +79,7 @@ export default function TailwindPlayer({ challenge, allDates }: TailwindPlayerPr
   const handleHtmlChange = useCallback((html: string) => {
     setUserHtml(html);
     userHtmlRef.current = html;
-    if (phaseRef.current !== 'playing') {
+    if (phaseRef.current === 'idle') {
       setPhase('playing');
       phaseRef.current = 'playing';
     }


### PR DESCRIPTION
## Summary
  - When the timer ran out and the user clicked "Keep Tweaking", any CSS edit would immediately re-trigger the results modal
  - Root cause: `handleCssChange` used `!== 'playing'` to detect when to start the timer, which also matched the `'finished'` phase — resetting it to
  `'playing'`, restarting the timer at 0, and immediately firing `onTimeUp` again
  - Fix: changed the condition to `=== 'idle'` in both `ChallengePlayer.tsx` and `TailwindPlayer.tsx` so only the initial start transitions the phase