### PR TITLE
Generator hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/docs/superpowers/plans/2026-06-10-generator-hardening.md
+++ b/docs/superpowers/plans/2026-06-10-generator-hardening.md
@@ -122,11 +122,11 @@ export function isOversize(size: { width: number; height: number }): boolean {
 
 - [ ] **Step 2: Smoke-test the helper against known-size fixtures**
 
-Write `/tmp/measure-smoke.ts`:
+Write `measure-smoke.ts` at the repo root (delete it after this step — do not commit it):
 
 ```ts
 import { chromium } from 'playwright';
-import { measureComponent, isOversize } from '/Users/tekgadgt/projects/cssdaily.dev/scripts/measure';
+import { measureComponent, isOversize } from './scripts/measure';
 
 const browser = await chromium.launch();
 const page = await browser.newPage();
@@ -151,7 +151,7 @@ await browser.close();
 Run:
 
 ```bash
-npx tsx /tmp/measure-smoke.ts
+npx tsx measure-smoke.ts && rm measure-smoke.ts
 ```
 
 Expected output ends with `PASS`. (Fixture 2: default block layout stacks the divs, so the union is 300 wide × 130 tall.)

--- a/docs/superpowers/plans/2026-06-10-generator-hardening.md
+++ b/docs/superpowers/plans/2026-06-10-generator-hardening.md
@@ -1,0 +1,548 @@
+# Generator Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pin emoji rendering to Noto Color Emoji everywhere challenges render, validate generated component size with a retry feedback loop, and nudge generations toward semantic HTML.
+
+**Architecture:** All challenge HTML is built through helpers in `src/utils/code.ts`, used by the player preview iframes, the snapdom diff captures, and the Playwright screenshot pipeline — so the font change happens once and applies everywhere. The two generator scripts (`scripts/generate-challenge.ts`, `scripts/generate-tailwind-challenge.ts`) are restructured from one-shot API calls into a measure-and-retry conversation loop using a shared Playwright measurement helper. Spec: `docs/superpowers/specs/2026-06-10-quality-improvements-design.md` (Package 1).
+
+**Tech Stack:** TypeScript, Anthropic SDK (multi-turn messages), Playwright, tsx. No test framework exists in this repo — verification is via targeted smoke scripts and `npm run build`.
+
+**Important context for the implementing engineer:**
+- The repo has zero automated tests and no test runner. Do not add one for this package. Each task includes explicit verification commands instead.
+- `scripts/generate-challenge.ts` and `scripts/generate-tailwind-challenge.ts` run daily in GitHub Actions with `ANTHROPIC_API_KEY`. Lines printed as `::warning::...` become GitHub Actions warning annotations.
+- Past challenges/targets are archival — do NOT regenerate any existing JSON or PNG (spec explicitly excludes backfill).
+- The viewport for all rendering is 600×400 with 20px body padding; the component size limit is 520×320.
+
+---
+
+### Task 1: Pin Noto Color Emoji in all rendering paths
+
+**Files:**
+- Modify: `src/utils/code.ts`
+
+- [ ] **Step 1: Update `FONT_LINK` and `BASE_STYLES`**
+
+In `src/utils/code.ts`, replace line 1:
+
+```ts
+export const FONT_LINK = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Color+Emoji&display=swap';
+```
+
+And in `BASE_STYLES`, change the body `font-family` line from:
+
+```css
+  font-family: 'Inter', sans-serif;
+```
+
+to:
+
+```css
+  font-family: 'Inter', 'Noto Color Emoji', sans-serif;
+```
+
+- [ ] **Step 2: Update the Tailwind body font class**
+
+In `buildTailwindSrcdoc` in the same file, change the body tag from:
+
+```html
+<body class="bg-[#f5f5f5] min-h-screen flex items-center justify-center p-5 font-['Inter']">
+```
+
+to:
+
+```html
+<body class="bg-[#f5f5f5] min-h-screen flex items-center justify-center p-5 font-['Inter','Noto_Color_Emoji']">
+```
+
+(Tailwind arbitrary values use underscores for spaces; commas separate font-stack entries.)
+
+- [ ] **Step 3: Verify the font URL resolves and the site builds**
+
+Run:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Color+Emoji&display=swap"
+npm run build
+```
+
+Expected: `200`, then a successful Astro build with no errors.
+
+- [ ] **Step 4: Visually verify emoji rendering (spot check)**
+
+Run `npm run dev`, open a past challenge that contains emoji (e.g. search with `grep -lE '[\x{1F300}-\x{1FAFF}]' src/data/challenges/*.json | head -3` to find one), and confirm the **Your Preview** panel renders emoji in Noto Color Emoji style (flat Google-style glyphs, not Apple's). The target PNG will still show old glyphs — that is expected (archival).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/code.ts
+git commit -m "Pin Noto Color Emoji font in all challenge rendering paths"
+```
+
+---
+
+### Task 2: Shared Playwright measurement helper
+
+**Files:**
+- Create: `scripts/measure.ts`
+
+- [ ] **Step 1: Create `scripts/measure.ts`**
+
+```ts
+import type { Page } from 'playwright';
+
+export const MAX_COMPONENT_WIDTH = 520;
+export const MAX_COMPONENT_HEIGHT = 320;
+
+/**
+ * Measure the bounding box of the rendered component: the union of
+ * document.body's direct children rects (the body is a flex container
+ * that centers the component; padding/background are environment chrome).
+ */
+export async function measureComponent(page: Page): Promise<{ width: number; height: number }> {
+  return page.evaluate(() => {
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const el of Array.from(document.body.children)) {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) continue;
+      minX = Math.min(minX, r.left);
+      minY = Math.min(minY, r.top);
+      maxX = Math.max(maxX, r.right);
+      maxY = Math.max(maxY, r.bottom);
+    }
+    if (minX === Infinity) return { width: 0, height: 0 };
+    return { width: Math.round(maxX - minX), height: Math.round(maxY - minY) };
+  });
+}
+
+export function isOversize(size: { width: number; height: number }): boolean {
+  return size.width > MAX_COMPONENT_WIDTH || size.height > MAX_COMPONENT_HEIGHT;
+}
+```
+
+- [ ] **Step 2: Smoke-test the helper against known-size fixtures**
+
+Write `/tmp/measure-smoke.ts`:
+
+```ts
+import { chromium } from 'playwright';
+import { measureComponent, isOversize } from '/Users/tekgadgt/projects/cssdaily.dev/scripts/measure';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+await page.setViewportSize({ width: 600, height: 400 });
+
+// Fixture 1: oversize width
+await page.setContent('<body style="margin:0;padding:20px"><div style="width:550px;height:100px"></div></body>');
+const a = await measureComponent(page);
+console.log('fixture 1:', a, 'oversize:', isOversize(a));
+if (a.width !== 550 || a.height !== 100 || !isOversize(a)) { console.error('FAIL fixture 1'); process.exit(1); }
+
+// Fixture 2: fits, two siblings (union box)
+await page.setContent('<body style="margin:0;padding:20px"><div style="width:200px;height:80px"></div><div style="width:300px;height:50px"></div></body>');
+const b = await measureComponent(page);
+console.log('fixture 2:', b, 'oversize:', isOversize(b));
+if (b.width !== 300 || b.height !== 130 || isOversize(b)) { console.error('FAIL fixture 2'); process.exit(1); }
+
+console.log('PASS');
+await browser.close();
+```
+
+Run:
+
+```bash
+npx tsx /tmp/measure-smoke.ts
+```
+
+Expected output ends with `PASS`. (Fixture 2: default block layout stacks the divs, so the union is 300 wide × 130 tall.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/measure.ts
+git commit -m "Add shared Playwright component-size measurement helper"
+```
+
+---
+
+### Task 3: Oversize retry loop + semantic HTML in CSS generator
+
+**Files:**
+- Modify: `scripts/generate-challenge.ts`
+
+- [ ] **Step 1: Add the semantic HTML line to the system prompt**
+
+In the `STRICT CONSTRAINTS` block of `SYSTEM_PROMPT`, after the line `- Focus on: flexbox, grid, spacing, borders, border-radius, typography (font-size, font-weight, line-height)`, add:
+
+```
+- Prefer semantic HTML elements (nav, article, section, header, footer, button, figure, ul/li) over generic divs where they fit naturally
+```
+
+- [ ] **Step 2: Restructure generation into a measure-and-retry loop**
+
+Replace the entire contents of `scripts/generate-challenge.ts` body below the `SYSTEM_PROMPT` declaration (the `generateChallenge` and `generateTargetPng` functions) with:
+
+```ts
+const MAX_ATTEMPTS = 4; // 1 initial generation + 3 size-fix retries
+
+interface ChallengeFields {
+  title: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  html: string;
+  targetCss: string;
+  starterCss: string;
+}
+
+function extractChallenge(text: string): ChallengeFields {
+  const extract = (tag: string): string => {
+    const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+    if (!match) throw new Error(`Missing <${tag}> in response:\n${text.substring(0, 500)}`);
+    return match[1].trim();
+  };
+
+  return {
+    title: extract('title'),
+    difficulty: extract('difficulty') as 'easy' | 'medium' | 'hard',
+    html: extract('html'),
+    targetCss: extract('targetcss'),
+    starterCss: extract('startercss'),
+  };
+}
+
+async function generateChallenge(date: string) {
+  // Collect recent challenge titles to avoid repeats
+  const recentTitles: string[] = [];
+  if (fs.existsSync(CHALLENGES_DIR)) {
+    const files = fs.readdirSync(CHALLENGES_DIR).filter((f) => f.endsWith('.json')).sort().reverse().slice(0, 30);
+    for (const file of files) {
+      try {
+        const data = JSON.parse(fs.readFileSync(path.join(CHALLENGES_DIR, file), 'utf-8'));
+        if (data.title) recentTitles.push(data.title);
+      } catch {}
+    }
+  }
+
+  let userPrompt = `Generate a CSS challenge for date ${date}.`;
+  if (recentTitles.length > 0) {
+    userPrompt += `\n\nRecent challenges (do NOT repeat these themes or similar variations):\n${recentTitles.map((t) => `- ${t}`).join('\n')}`;
+  }
+
+  const client = new Anthropic();
+  const messages: Anthropic.MessageParam[] = [{ role: 'user', content: userPrompt }];
+
+  const chromiumPath = process.env.CHROMIUM_PATH;
+  const browser = await chromium.launch({
+    ...(chromiumPath ? { executablePath: chromiumPath } : {}),
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.setViewportSize({ width: 600, height: 400 });
+
+    let fields: ChallengeFields | null = null;
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      const message = await client.messages.create({
+        model: 'claude-sonnet-4-6',
+        max_tokens: 4000,
+        messages,
+        system: SYSTEM_PROMPT,
+      });
+
+      const text = (message.content[0] as { type: 'text'; text: string }).text;
+      fields = extractChallenge(text);
+
+      // Render the target and measure the component (this render is also
+      // reused for the screenshot once the size is accepted)
+      await page.setContent(buildScreenshotHtml(fields.html, fields.targetCss), { waitUntil: 'networkidle' });
+      const size = await measureComponent(page);
+
+      if (!isOversize(size)) {
+        console.log(`Attempt ${attempt}: component is ${size.width}x${size.height}px — OK`);
+        break;
+      }
+
+      console.warn(`Attempt ${attempt}: component is ${size.width}x${size.height}px (max ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT})`);
+
+      if (attempt === MAX_ATTEMPTS) {
+        // Ship it anyway — a slightly clipped challenge beats a missing day
+        console.log(`::warning::CSS challenge for ${date} shipped oversize at ${size.width}x${size.height}px after ${MAX_ATTEMPTS} attempts`);
+        break;
+      }
+
+      messages.push({ role: 'assistant', content: text });
+      messages.push({
+        role: 'user',
+        content: `Your component rendered at ${size.width}x${size.height}px, which exceeds the ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT}px maximum. Regenerate the challenge with a more compact layout that fits within ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT}px — reduce padding, font sizes, or element count as needed. Output all the XML tags again in full.`,
+      });
+    }
+
+    if (!fields) throw new Error('Generation produced no challenge');
+
+    const challenge = {
+      title: fields.title,
+      difficulty: fields.difficulty,
+      target: { html: fields.html, css: fields.targetCss },
+      starter: { html: fields.html, css: fields.starterCss },
+      date,
+      timeLimit: fields.difficulty === 'easy' ? 300 : fields.difficulty === 'hard' ? 900 : 600,
+    };
+
+    // Save JSON
+    fs.mkdirSync(CHALLENGES_DIR, { recursive: true });
+    const jsonPath = path.join(CHALLENGES_DIR, `${date}.json`);
+    fs.writeFileSync(jsonPath, JSON.stringify(challenge, null, 2));
+    console.log(`Saved challenge JSON: ${jsonPath}`);
+
+    // Screenshot the already-rendered accepted attempt
+    fs.mkdirSync(TARGETS_DIR, { recursive: true });
+    const pngPath = path.join(TARGETS_DIR, `${date}.png`);
+    await page.screenshot({ path: pngPath, type: 'png' });
+    console.log(`Saved target PNG: ${pngPath}`);
+  } finally {
+    await browser.close();
+  }
+}
+```
+
+Update the imports at the top of the file:
+
+```ts
+import Anthropic from '@anthropic-ai/sdk';
+import { chromium } from 'playwright';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { buildScreenshotHtml } from '../src/utils/code';
+import { measureComponent, isOversize, MAX_COMPONENT_WIDTH, MAX_COMPONENT_HEIGHT } from './measure';
+```
+
+Keep the existing CLI block at the bottom of the file (the `const date = process.argv[2] || ...` and `generateChallenge(date).then(...)` lines) unchanged.
+
+- [ ] **Step 3: Type-check**
+
+Run:
+
+```bash
+npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors. (If the project tsconfig doesn't cover `scripts/`, run `npx tsc --noEmit scripts/generate-challenge.ts --module esnext --moduleResolution bundler --target es2022 --skipLibCheck` instead and expect no errors.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/generate-challenge.ts
+git commit -m "Add oversize measure-and-retry loop and semantic HTML guidance to CSS generator"
+```
+
+---
+
+### Task 4: Oversize retry loop + semantic HTML in Tailwind generator
+
+**Files:**
+- Modify: `scripts/generate-tailwind-challenge.ts`
+
+- [ ] **Step 1: Add the semantic HTML line to the system prompt**
+
+In the `STRICT CONSTRAINTS` block of `SYSTEM_PROMPT`, after the line `- Focus on: flexbox, grid, spacing, borders, border-radius, typography, colors`, add:
+
+```
+- Prefer semantic HTML elements (nav, article, section, header, footer, button, figure, ul/li) over generic divs where they fit naturally
+```
+
+- [ ] **Step 2: Restructure generation into a measure-and-retry loop**
+
+Replace the `generateChallenge` and `generateTargetPng` functions in `scripts/generate-tailwind-challenge.ts` with:
+
+```ts
+const MAX_ATTEMPTS = 4; // 1 initial generation + 3 size-fix retries
+
+interface TailwindChallengeFields {
+  title: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  targetHtml: string;
+  starterHtml: string;
+}
+
+function extractChallenge(text: string): TailwindChallengeFields {
+  const extract = (tag: string): string => {
+    const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+    if (!match) throw new Error(`Missing <${tag}> in response:\n${text.substring(0, 500)}`);
+    return match[1].trim();
+  };
+
+  return {
+    title: extract('title'),
+    difficulty: extract('difficulty') as 'easy' | 'medium' | 'hard',
+    targetHtml: extract('targethtml'),
+    starterHtml: extract('starterhtml'),
+  };
+}
+
+async function generateChallenge(date: string) {
+  const recentTitles: string[] = [];
+  if (fs.existsSync(CHALLENGES_DIR)) {
+    const files = fs.readdirSync(CHALLENGES_DIR).filter((f) => f.endsWith('.json')).sort().reverse().slice(0, 30);
+    for (const file of files) {
+      try {
+        const data = JSON.parse(fs.readFileSync(path.join(CHALLENGES_DIR, file), 'utf-8'));
+        if (data.title) recentTitles.push(data.title);
+      } catch {}
+    }
+  }
+
+  let userPrompt = `Generate a Tailwind CSS challenge for date ${date}.`;
+  if (recentTitles.length > 0) {
+    userPrompt += `\n\nRecent challenges (do NOT repeat these themes or similar variations):\n${recentTitles.map((t) => `- ${t}`).join('\n')}`;
+  }
+
+  const client = new Anthropic();
+  const messages: Anthropic.MessageParam[] = [{ role: 'user', content: userPrompt }];
+
+  const chromiumPath = process.env.CHROMIUM_PATH;
+  const browser = await chromium.launch({
+    ...(chromiumPath ? { executablePath: chromiumPath } : {}),
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.setViewportSize({ width: 600, height: 400 });
+
+    let fields: TailwindChallengeFields | null = null;
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      const message = await client.messages.create({
+        model: 'claude-sonnet-4-6',
+        max_tokens: 4000,
+        messages,
+        system: SYSTEM_PROMPT,
+      });
+
+      const text = (message.content[0] as { type: 'text'; text: string }).text;
+      fields = extractChallenge(text);
+
+      await page.setContent(buildTailwindScreenshotHtml(fields.targetHtml), { waitUntil: 'networkidle' });
+      const size = await measureComponent(page);
+
+      if (!isOversize(size)) {
+        console.log(`Attempt ${attempt}: component is ${size.width}x${size.height}px — OK`);
+        break;
+      }
+
+      console.warn(`Attempt ${attempt}: component is ${size.width}x${size.height}px (max ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT})`);
+
+      if (attempt === MAX_ATTEMPTS) {
+        console.log(`::warning::Tailwind challenge for ${date} shipped oversize at ${size.width}x${size.height}px after ${MAX_ATTEMPTS} attempts`);
+        break;
+      }
+
+      messages.push({ role: 'assistant', content: text });
+      messages.push({
+        role: 'user',
+        content: `Your component rendered at ${size.width}x${size.height}px, which exceeds the ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT}px maximum. Regenerate the challenge with a more compact layout that fits within ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT}px — reduce padding, text sizes, or element count as needed. Output all the XML tags again in full.`,
+      });
+    }
+
+    if (!fields) throw new Error('Generation produced no challenge');
+
+    const challenge = {
+      title: fields.title,
+      difficulty: fields.difficulty,
+      date,
+      timeLimit: fields.difficulty === 'easy' ? 300 : fields.difficulty === 'hard' ? 900 : 600,
+      starter: { html: fields.starterHtml },
+      target: { html: fields.targetHtml },
+    };
+
+    fs.mkdirSync(CHALLENGES_DIR, { recursive: true });
+    const jsonPath = path.join(CHALLENGES_DIR, `${date}.json`);
+    fs.writeFileSync(jsonPath, JSON.stringify(challenge, null, 2));
+    console.log(`Saved Tailwind challenge JSON: ${jsonPath}`);
+
+    fs.mkdirSync(TARGETS_DIR, { recursive: true });
+    const pngPath = path.join(TARGETS_DIR, `${date}.png`);
+    await page.screenshot({ path: pngPath, type: 'png' });
+    console.log(`Saved Tailwind target PNG: ${pngPath}`);
+  } finally {
+    await browser.close();
+  }
+}
+```
+
+Update the imports at the top of the file:
+
+```ts
+import Anthropic from '@anthropic-ai/sdk';
+import { chromium } from 'playwright';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { buildTailwindScreenshotHtml } from '../src/utils/code';
+import { measureComponent, isOversize, MAX_COMPONENT_WIDTH, MAX_COMPONENT_HEIGHT } from './measure';
+```
+
+Keep the existing CLI block at the bottom unchanged.
+
+Note: the Tailwind screenshot HTML loads the Tailwind CDN, so `waitUntil: 'networkidle'` matters here — it already matches the existing behavior.
+
+- [ ] **Step 3: Type-check**
+
+Run:
+
+```bash
+npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors (same fallback as Task 3 Step 3 if `scripts/` isn't covered).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/generate-tailwind-challenge.ts
+git commit -m "Add oversize measure-and-retry loop and semantic HTML guidance to Tailwind generator"
+```
+
+---
+
+### Task 5: End-to-end verification with a throwaway date
+
+Requires `ANTHROPIC_API_KEY` in the environment (a few Sonnet calls, ~$0.05). If no key is available locally, skip and verify via a `workflow_dispatch` run of the Generate Daily Challenge action instead — but do not merge unverified.
+
+- [ ] **Step 1: Run both generators for a sentinel date**
+
+```bash
+npx tsx scripts/generate-challenge.ts 2099-01-01
+npx tsx scripts/generate-tailwind-challenge.ts 2099-01-01
+```
+
+Expected: each prints `Attempt N: component is WxHpx — OK` (almost always attempt 1), then `Saved challenge JSON` / `Saved ... target PNG`, then `CHALLENGE_DATE=2099-01-01`. The logged W×H must be ≤ 520×320 unless an `::warning::` line says it shipped oversize.
+
+- [ ] **Step 2: Inspect the artifacts**
+
+```bash
+cat src/data/challenges/2099-01-01.json | head -20
+open public/targets/2099-01-01.png
+open public/targets/tailwind/2099-01-01.png
+```
+
+Expected: valid JSON with title/difficulty/starter/target; PNGs show the full component unclipped, with any emoji rendered in Noto Color Emoji (flat Google) style.
+
+- [ ] **Step 3: Delete the sentinel artifacts**
+
+```bash
+rm src/data/challenges/2099-01-01.json src/data/tailwind-challenges/2099-01-01.json
+rm public/targets/2099-01-01.png public/targets/tailwind/2099-01-01.png
+git status
+```
+
+Expected: `git status` shows a clean tree (nothing staged or untracked from the sentinel run).
+
+- [ ] **Step 4: Final build check and verify clean state**
+
+```bash
+npm run build
+git log --oneline -5
+```
+
+Expected: build succeeds; the log shows the three commits from Tasks 1–4 on top.

--- a/docs/superpowers/specs/2026-06-10-quality-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-10-quality-improvements-design.md
@@ -26,7 +26,7 @@ Pin emoji rendering to one font everywhere a challenge renders:
 
 Because the Playwright screenshot env, the player preview iframes, and the snapdom diff captures all build HTML through these same helpers, the generator and every player OS render identical emoji.
 
-**Backfill:** regenerate all existing target PNGs in one batch (re-render each challenge JSON through the updated screenshot pipeline). Challenge JSONs are unchanged; only `public/targets/*.png` are rewritten.
+**No backfill:** existing target PNGs stay as-is — the emoji mismatch on past challenges is a known issue and they remain archival. The fix applies to challenges generated from this point forward (the player-side font change does apply everywhere, since previews render live).
 
 ### 1b. Oversize validation with retry loop
 

--- a/docs/superpowers/specs/2026-06-10-quality-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-10-quality-improvements-design.md
@@ -1,0 +1,126 @@
+# Quality Improvements — Design
+
+**Date:** 2026-06-10
+**Status:** Approved
+
+Four work packages addressing player-reported issues, sequenced by priority. Each package ships independently.
+
+## Background
+
+Findings from codebase analysis that motivated this design:
+
+- 61 of 99 CSS challenges contain emoji, but no emoji font is pinned. The target PNG is rendered by Playwright on Linux CI while players render previews on their own OS, so the reference screenshot shows different emoji glyphs than the player's preview. Scoring is unaffected (both diff inputs render client-side), but the reference is misleading.
+- 98 of 99 challenges are labeled `medium` because the model picks the difficulty itself.
+- The generator trusts the prompt's "max 520×320px" constraint with no post-generation validation, causing occasional clipped targets.
+- Target and starter HTML are identical in both game modes, which makes element-level structural comparison trivial (1:1 correspondence by tree order).
+
+## Package 1: Generator hardening
+
+### 1a. Emoji consistency (Noto Color Emoji webfont)
+
+Pin emoji rendering to one font everywhere a challenge renders:
+
+- `FONT_LINK` in `src/utils/code.ts` adds the Google Fonts request for Noto Color Emoji alongside Inter.
+- `BASE_STYLES` font-family becomes `'Inter', 'Noto Color Emoji', sans-serif`.
+- `buildTailwindSrcdoc` body font class gains the same fallback.
+
+Because the Playwright screenshot env, the player preview iframes, and the snapdom diff captures all build HTML through these same helpers, the generator and every player OS render identical emoji.
+
+**Backfill:** regenerate all existing target PNGs in one batch (re-render each challenge JSON through the updated screenshot pipeline). Challenge JSONs are unchanged; only `public/targets/*.png` are rewritten.
+
+### 1b. Oversize validation with retry loop
+
+In `scripts/generate-challenge.ts` and `scripts/generate-tailwind-challenge.ts`, after rendering the target in Playwright:
+
+1. Measure the rendered component's bounding box (union of `document.body` children rects).
+2. If it exceeds 520×320, append a follow-up user message to the same conversation: the measured W×H, the limit, and an instruction to regenerate smaller. Re-extract, re-render, re-measure.
+3. Up to 3 retries; if still oversize, the script exits nonzero (the workflow's `continue-on-error` already tolerates a failed day).
+
+### 1c. Semantic HTML prompt guidance
+
+Add a system-prompt line instructing the generator to prefer semantic elements (`nav`, `article`, `section`, `button`, `figure`, etc.) where they fit naturally. Guidance only — not validated.
+
+## Package 2: Layout toggle (rows ⇄ columns)
+
+A manual layout toggle for both `ChallengePlayer` and `TailwindPlayer`:
+
+- **Rows (current/default):** previews side-by-side on top, editor full-width below.
+- **Columns:** the two preview panels stacked vertically in a left column, editor filling the right column.
+
+Details:
+
+- Toggle button in the player header (icon button, e.g. layout glyphs).
+- Preference persisted to localStorage under a single shared key — one preference covers both game modes.
+- Manual only; no breakpoint-driven switching.
+
+## Package 3: Three difficulties daily
+
+Replace the model-chosen single difficulty with three generated challenges per day per mode: one easy, one medium, one hard.
+
+### Generation
+
+- Each generator script loops over the three difficulties, producing three challenges per run. Each difficulty generates independently (a failure in one does not abort the others); the script exits nonzero only if all three fail, and the CI step summary reports per-difficulty outcomes.
+- The prompt receives concrete per-difficulty criteria (approximate element count, CSS property count, layout nesting depth — exact rubric defined during implementation).
+- `timeLimit` mapping stays: easy 300s, medium 600s, hard 900s.
+- 6 API calls/day total across both modes.
+
+### Data layout
+
+- New files: `src/data/challenges/YYYY-MM-DD-easy.json`, `-medium.json`, `-hard.json`; targets `public/targets/YYYY-MM-DD-easy.png`, etc. Same shape as today (each JSON already carries `difficulty`).
+- Existing single files (`YYYY-MM-DD.json` / `.png`) remain valid as-is; they are treated as the sole challenge for their date.
+
+### Pages and player
+
+- `getStaticPaths` groups challenge files by date; each `/challenge/[date]` (and `/tailwind/[date]`) page receives all difficulties available for that date as props. Still fully static.
+- The player shows an Easy / Medium / Hard toggle beside the title. Switching swaps the active challenge in place (editor content, target image, timer, score state) without navigation. Each difficulty's in-progress editor state is kept separately while on the page.
+- Last-played difficulty persisted to localStorage and used as the default selection.
+- Dates with a single legacy challenge hide the toggle.
+- Target image paths come from a challenge-derived key (`date` for legacy, `date-difficulty` for new) rather than date alone.
+
+### Results and stats
+
+- Storage schema becomes `history[date][difficulty]` with separate score/time/submission per difficulty, for both the CSS and Tailwind storage keys.
+- One-time migration on first read: existing flat entries move to `history[date][difficulty]` using the entry's challenge difficulty when known, else `medium` (98/99 accurate).
+- Streaks: a day counts as played if any difficulty was submitted that day.
+- Stats (games played, average) count each submitted difficulty as a game.
+- Share card lists each attempted difficulty with its score.
+
+## Package 4: Structural scoring
+
+Add an element-level metric so correct structure/size/position is rewarded, not just pixel color overlap.
+
+### Generation side
+
+After the target render in Playwright, walk every element inside `body` in document order and record its bounding box (`x`, `y`, `width`, `height`, viewport-relative). Store as `targetRects: Rect[]` in the challenge JSON.
+
+### Client side
+
+- After each diff render, measure the same elements in the user's preview iframe in document order (`getBoundingClientRect`), producing 1:1 pairs with `targetRects` (HTML structure is identical by construction). The player preview iframe and the generation viewport are both 600×400, so rects compare directly with no scaling.
+- Per-element score: IoU (intersection-over-union) of user rect vs target rect; 0 when disjoint.
+- Structural score = mean IoU across elements, as 0–100.
+
+### Blending
+
+- `finalScore = round(0.6 * pixelScore + 0.4 * structuralScore)` — weights are named constants, tunable.
+- `pixelScore` is the existing power-curved pixel diff score.
+- Challenges without `targetRects` (all existing ones) score pixel-only — no retroactive changes.
+- The score display may show the two components in a tooltip/breakdown (implementation detail).
+
+### Tailwind mode
+
+Works identically: the DOM structure is fixed (players edit only class values), so tree-order correspondence holds. Generation-side rects are measured in the same Playwright render that produces the Tailwind target screenshot.
+
+## Out of scope
+
+- Selector hover highlighting in the preview — dropped: it cannot achieve parity between CSS and Tailwind modes (Tailwind players don't write selectors).
+- Reactive/breakpoint-driven layout switching (manual toggle only).
+- Difficulty-based scoring adjustments or leaderboards.
+
+## Sequencing
+
+1. Generator hardening — kills both live bugs (clipping, emoji mismatch).
+2. Layout toggle — small UX win; lands before the player components get reworked by Package 3.
+3. Three difficulties daily — largest change (generation, data, pages, storage migration).
+4. Structural scoring — additive, builds on the generation pipeline as it stands after Package 3.
+
+Each package is a separate implementation plan and PR-sized unit of work.

--- a/docs/superpowers/specs/2026-06-10-quality-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-10-quality-improvements-design.md
@@ -34,7 +34,7 @@ In `scripts/generate-challenge.ts` and `scripts/generate-tailwind-challenge.ts`,
 
 1. Measure the rendered component's bounding box (union of `document.body` children rects).
 2. If it exceeds 520×320, append a follow-up user message to the same conversation: the measured W×H, the limit, and an instruction to regenerate smaller. Re-extract, re-render, re-measure.
-3. Up to 3 retries; if still oversize, the script exits nonzero (the workflow's `continue-on-error` already tolerates a failed day).
+3. Up to 3 retries; if still oversize after the final retry, ship the last attempt anyway (log a warning in the CI summary). An occasionally clipped challenge beats a missing day — if oversize persists after this lands, that's a signal to dig into the root cause.
 
 ### 1c. Semantic HTML prompt guidance
 

--- a/scripts/generate-challenge.ts
+++ b/scripts/generate-challenge.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { buildScreenshotHtml } from '../src/utils/code';
+import { measureComponent, isOversize, MAX_COMPONENT_WIDTH, MAX_COMPONENT_HEIGHT } from './measure';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CHALLENGES_DIR = path.join(__dirname, '..', 'src', 'data', 'challenges');
@@ -19,6 +20,7 @@ STRICT CONSTRAINTS:
 - Component must not exceed 520x320px (hard max within 600x400 viewport)
 - Body background is always #f5f5f5 (set by environment)
 - Focus on: flexbox, grid, spacing, borders, border-radius, typography (font-size, font-weight, line-height)
+- Prefer semantic HTML elements (nav, article, section, header, footer, button, figure, ul/li) over generic divs where they fit naturally
 
 SIZING STRATEGY (viewport is 600x400, body has 20px padding on all sides):
 - Available canvas: 560x360px. Component must fit comfortably within this.
@@ -37,6 +39,32 @@ OUTPUT FORMAT — use these exact XML tags (no JSON, no code fences):
 
 The starter CSS must include the same :root block with ALL variables, plus empty selector stubs for each class/element used in the target CSS.
 Generate creative, visually interesting components like cards, badges, buttons, navbars, pricing tables, etc.`;
+
+const MAX_ATTEMPTS = 4; // 1 initial generation + 3 size-fix retries
+
+interface ChallengeFields {
+  title: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  html: string;
+  targetCss: string;
+  starterCss: string;
+}
+
+function extractChallenge(text: string): ChallengeFields {
+  const extract = (tag: string): string => {
+    const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+    if (!match) throw new Error(`Missing <${tag}> in response:\n${text.substring(0, 500)}`);
+    return match[1].trim();
+  };
+
+  return {
+    title: extract('title'),
+    difficulty: extract('difficulty') as 'easy' | 'medium' | 'hard',
+    html: extract('html'),
+    targetCss: extract('targetcss'),
+    starterCss: extract('startercss'),
+  };
+}
 
 async function generateChallenge(date: string) {
   // Collect recent challenge titles to avoid repeats
@@ -57,71 +85,80 @@ async function generateChallenge(date: string) {
   }
 
   const client = new Anthropic();
+  const messages: Anthropic.MessageParam[] = [{ role: 'user', content: userPrompt }];
 
-  const message = await client.messages.create({
-    model: 'claude-sonnet-4-6',
-    max_tokens: 4000,
-    messages: [
-      {
-        role: 'user',
-        content: userPrompt,
-      },
-    ],
-    system: SYSTEM_PROMPT,
-  });
-
-  const text = (message.content[0] as { type: 'text'; text: string }).text;
-
-  // Extract fields from XML tags
-  const extract = (tag: string): string => {
-    const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
-    if (!match) throw new Error(`Missing <${tag}> in response:\n${text.substring(0, 500)}`);
-    return match[1].trim();
-  };
-
-  const title = extract('title');
-  const difficulty = extract('difficulty') as 'easy' | 'medium' | 'hard';
-  const html = extract('html');
-  const targetCss = extract('targetcss');
-  const starterCss = extract('startercss');
-
-  const challenge = {
-    title,
-    difficulty,
-    target: { html, css: targetCss },
-    starter: { html, css: starterCss },
-    date,
-    timeLimit: difficulty === 'easy' ? 300 : difficulty === 'hard' ? 900 : 600,
-  };
-
-  // Save JSON
-  fs.mkdirSync(CHALLENGES_DIR, { recursive: true });
-  const jsonPath = path.join(CHALLENGES_DIR, `${date}.json`);
-  fs.writeFileSync(jsonPath, JSON.stringify(challenge, null, 2));
-  console.log(`Saved challenge JSON: ${jsonPath}`);
-
-  // Generate target screenshot
-  await generateTargetPng(challenge);
-}
-
-async function generateTargetPng(challenge: any) {
   const chromiumPath = process.env.CHROMIUM_PATH;
   const browser = await chromium.launch({
     ...(chromiumPath ? { executablePath: chromiumPath } : {}),
   });
 
-  const page = await browser.newPage();
-  await page.setViewportSize({ width: 600, height: 400 });
+  try {
+    const page = await browser.newPage();
+    await page.setViewportSize({ width: 600, height: 400 });
 
-  const html = buildScreenshotHtml(challenge.target.html, challenge.target.css);
-  await page.setContent(html, { waitUntil: 'networkidle' });
+    let fields: ChallengeFields | null = null;
 
-  fs.mkdirSync(TARGETS_DIR, { recursive: true });
-  const pngPath = path.join(TARGETS_DIR, `${challenge.date}.png`);
-  await page.screenshot({ path: pngPath, type: 'png' });
-  console.log(`Saved target PNG: ${pngPath}`);
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      const message = await client.messages.create({
+        model: 'claude-sonnet-4-6',
+        max_tokens: 4000,
+        messages,
+        system: SYSTEM_PROMPT,
+      });
 
-  await browser.close();
+      const text = (message.content[0] as { type: 'text'; text: string }).text;
+      fields = extractChallenge(text);
+
+      // Render the target and measure the component (this render is also
+      // reused for the screenshot once the size is accepted)
+      await page.setContent(buildScreenshotHtml(fields.html, fields.targetCss), { waitUntil: 'networkidle' });
+      const size = await measureComponent(page);
+
+      if (!isOversize(size)) {
+        console.log(`Attempt ${attempt}: component is ${size.width}x${size.height}px — OK`);
+        break;
+      }
+
+      console.warn(`Attempt ${attempt}: component is ${size.width}x${size.height}px (max ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT})`);
+
+      if (attempt === MAX_ATTEMPTS) {
+        // Ship it anyway — a slightly clipped challenge beats a missing day
+        console.log(`::warning::CSS challenge for ${date} shipped oversize at ${size.width}x${size.height}px after ${MAX_ATTEMPTS} attempts`);
+        break;
+      }
+
+      messages.push({ role: 'assistant', content: text });
+      messages.push({
+        role: 'user',
+        content: `Your component rendered at ${size.width}x${size.height}px, which exceeds the ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT}px maximum. Regenerate the challenge with a more compact layout that fits within ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT}px — reduce padding, font sizes, or element count as needed. Output all the XML tags again in full.`,
+      });
+    }
+
+    if (!fields) throw new Error('Generation produced no challenge');
+
+    const challenge = {
+      title: fields.title,
+      difficulty: fields.difficulty,
+      target: { html: fields.html, css: fields.targetCss },
+      starter: { html: fields.html, css: fields.starterCss },
+      date,
+      timeLimit: fields.difficulty === 'easy' ? 300 : fields.difficulty === 'hard' ? 900 : 600,
+    };
+
+    // Save JSON
+    fs.mkdirSync(CHALLENGES_DIR, { recursive: true });
+    const jsonPath = path.join(CHALLENGES_DIR, `${date}.json`);
+    fs.writeFileSync(jsonPath, JSON.stringify(challenge, null, 2));
+    console.log(`Saved challenge JSON: ${jsonPath}`);
+
+    // Screenshot the already-rendered accepted attempt
+    fs.mkdirSync(TARGETS_DIR, { recursive: true });
+    const pngPath = path.join(TARGETS_DIR, `${date}.png`);
+    await page.screenshot({ path: pngPath, type: 'png' });
+    console.log(`Saved target PNG: ${pngPath}`);
+  } finally {
+    await browser.close();
+  }
 }
 
 // CLI — defaults to tomorrow's date so the cron generates ahead of time

--- a/scripts/generate-challenge.ts
+++ b/scripts/generate-challenge.ts
@@ -12,7 +12,7 @@ const TARGETS_DIR = path.join(__dirname, '..', 'public', 'targets');
 const SYSTEM_PROMPT = `You are a CSS challenge generator for a "Wordle for CSS" game. Generate a self-contained CSS challenge that users will try to replicate.
 
 STRICT CONSTRAINTS:
-- NO font-family declarations (Inter font is loaded by the environment)
+- NO font-family declarations (Inter and Noto Color Emoji fonts are loaded and set by the environment)
 - NO box-shadow or text-shadow (inconsistent rendering)
 - NO background-image, url(), or external assets
 - ALL colors must be defined as :root CSS custom properties with var() references

--- a/scripts/generate-challenge.ts
+++ b/scripts/generate-challenge.ts
@@ -106,12 +106,32 @@ async function generateChallenge(date: string) {
         system: SYSTEM_PROMPT,
       });
 
-      const text = (message.content[0] as { type: 'text'; text: string }).text;
-      fields = extractChallenge(text);
+      const block = message.content[0];
+      if (!block || block.type !== 'text') {
+        throw new Error(`Unexpected response content on attempt ${attempt}: ${JSON.stringify(message.content).substring(0, 200)}`);
+      }
+      const text = block.text;
+
+      let parsed: ChallengeFields;
+      try {
+        parsed = extractChallenge(text);
+      } catch (err) {
+        console.warn(`Attempt ${attempt}: failed to parse response — ${(err as Error).message}`);
+        if (attempt === MAX_ATTEMPTS) throw err;
+        messages.push({ role: 'assistant', content: text });
+        messages.push({
+          role: 'user',
+          content: 'Your previous response was missing required XML tags. Output the complete challenge again with ALL of these tags: <title>, <difficulty>, <html>, <targetcss>, <startercss>.',
+        });
+        continue;
+      }
 
       // Render the target and measure the component (this render is also
       // reused for the screenshot once the size is accepted)
-      await page.setContent(buildScreenshotHtml(fields.html, fields.targetCss), { waitUntil: 'networkidle' });
+      await page.setContent(buildScreenshotHtml(parsed.html, parsed.targetCss), { waitUntil: 'networkidle' });
+      // Only assign fields after a successful render so fields, the rendered
+      // page, and the eventual screenshot always correspond to the same attempt.
+      fields = parsed;
       const size = await measureComponent(page);
 
       if (!isOversize(size)) {
@@ -151,7 +171,7 @@ async function generateChallenge(date: string) {
     fs.writeFileSync(jsonPath, JSON.stringify(challenge, null, 2));
     console.log(`Saved challenge JSON: ${jsonPath}`);
 
-    // Screenshot the already-rendered accepted attempt
+    // Screenshot the last rendered attempt (accepted, or shipped-anyway oversize)
     fs.mkdirSync(TARGETS_DIR, { recursive: true });
     const pngPath = path.join(TARGETS_DIR, `${date}.png`);
     await page.screenshot({ path: pngPath, type: 'png' });
@@ -171,4 +191,7 @@ const date = process.argv[2] || (() => {
 generateChallenge(date).then(() => {
   // Write date to stdout for CI to capture
   console.log(`CHALLENGE_DATE=${date}`);
-}).catch(console.error);
+}).catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/generate-challenge.ts
+++ b/scripts/generate-challenge.ts
@@ -23,7 +23,7 @@ STRICT CONSTRAINTS:
 - Prefer semantic HTML elements (nav, article, section, header, footer, button, figure, ul/li) over generic divs where they fit naturally
 
 SIZING STRATEGY (viewport is 600x400, body has 20px padding on all sides):
-- Available canvas: 560x360px. Component must fit comfortably within this.
+- Your size budget is 520x320px — the same hard max as above. Design toward ~480x280 so you never brush the limit.
 - Height is the tight dimension — keep components SHORT. Max ~6-8 visible elements stacked vertically.
 - Width is generous — use it. Prefer side-by-side layouts (flexbox row, grid columns) over tall single-column stacks.
 - Use compact spacing: small/medium padding (8-16px), tight margins/gaps (4-12px). Avoid large spacing values.

--- a/scripts/generate-tailwind-challenge.ts
+++ b/scripts/generate-tailwind-challenge.ts
@@ -27,7 +27,7 @@ STRICT CONSTRAINTS:
 - Target HTML has the correct Tailwind utility classes
 
 SIZING STRATEGY (viewport is 600x400, body has 20px padding on all sides):
-- Available canvas: 560x360px. Component must fit comfortably within this.
+- Your size budget is 520x320px — the same hard max as above. Design toward ~480x280 so you never brush the limit.
 - Height is the tight dimension — keep components SHORT. Max ~6-8 visible elements stacked vertically.
 - Width is generous — use it. Prefer side-by-side layouts (flexbox row, grid columns) over tall single-column stacks.
 - Use compact spacing: prefer p-3/p-4 over p-6/p-8, gap-2/gap-3 over gap-6/gap-8, mb-2/mb-3 over mb-6/mb-8.

--- a/scripts/generate-tailwind-challenge.ts
+++ b/scripts/generate-tailwind-challenge.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { buildTailwindScreenshotHtml } from '../src/utils/code';
+import { measureComponent, isOversize, MAX_COMPONENT_WIDTH, MAX_COMPONENT_HEIGHT } from './measure';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CHALLENGES_DIR = path.join(__dirname, '..', 'src', 'data', 'tailwind-challenges');
@@ -18,6 +19,7 @@ STRICT CONSTRAINTS:
 - Body background is always #f5f5f5 (set by environment)
 - Use Tailwind's built-in color palette (no custom colors)
 - Focus on: flexbox, grid, spacing, borders, border-radius, typography, colors
+- Prefer semantic HTML elements (nav, article, section, header, footer, button, figure, ul/li) over generic divs where they fit naturally
 - NO box-shadow, text-shadow, or background-image utilities
 - NO font-family declarations (Inter and Noto Color Emoji fonts are loaded and set by the environment)
 - The starter HTML and target HTML must have the SAME structure — only class values differ
@@ -40,7 +42,32 @@ OUTPUT FORMAT — use these exact XML tags (no JSON, no code fences):
 
 Generate creative, visually interesting components like cards, badges, buttons, navbars, pricing tables, profile cards, etc.`;
 
+const MAX_ATTEMPTS = 4; // 1 initial generation + 3 size-fix retries
+
+interface TailwindChallengeFields {
+  title: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  targetHtml: string;
+  starterHtml: string;
+}
+
+function extractChallenge(text: string): TailwindChallengeFields {
+  const extract = (tag: string): string => {
+    const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+    if (!match) throw new Error(`Missing <${tag}> in response:\n${text.substring(0, 500)}`);
+    return match[1].trim();
+  };
+
+  return {
+    title: extract('title'),
+    difficulty: extract('difficulty') as 'easy' | 'medium' | 'hard',
+    targetHtml: extract('targethtml'),
+    starterHtml: extract('starterhtml'),
+  };
+}
+
 async function generateChallenge(date: string) {
+  // Collect recent challenge titles to avoid repeats
   const recentTitles: string[] = [];
   if (fs.existsSync(CHALLENGES_DIR)) {
     const files = fs.readdirSync(CHALLENGES_DIR).filter((f) => f.endsWith('.json')).sort().reverse().slice(0, 30);
@@ -58,69 +85,103 @@ async function generateChallenge(date: string) {
   }
 
   const client = new Anthropic();
+  const messages: Anthropic.MessageParam[] = [{ role: 'user', content: userPrompt }];
 
-  const message = await client.messages.create({
-    model: 'claude-sonnet-4-6',
-    max_tokens: 4000,
-    messages: [
-      {
-        role: 'user',
-        content: userPrompt,
-      },
-    ],
-    system: SYSTEM_PROMPT,
-  });
-
-  const text = (message.content[0] as { type: 'text'; text: string }).text;
-
-  const extract = (tag: string): string => {
-    const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
-    if (!match) throw new Error(`Missing <${tag}> in response:\n${text.substring(0, 500)}`);
-    return match[1].trim();
-  };
-
-  const title = extract('title');
-  const difficulty = extract('difficulty') as 'easy' | 'medium' | 'hard';
-  const targetHtml = extract('targethtml');
-  const starterHtml = extract('starterhtml');
-
-  const challenge = {
-    title,
-    difficulty,
-    date,
-    timeLimit: difficulty === 'easy' ? 300 : difficulty === 'hard' ? 900 : 600,
-    starter: { html: starterHtml },
-    target: { html: targetHtml },
-  };
-
-  fs.mkdirSync(CHALLENGES_DIR, { recursive: true });
-  const jsonPath = path.join(CHALLENGES_DIR, `${date}.json`);
-  fs.writeFileSync(jsonPath, JSON.stringify(challenge, null, 2));
-  console.log(`Saved Tailwind challenge JSON: ${jsonPath}`);
-
-  await generateTargetPng(challenge);
-}
-
-async function generateTargetPng(challenge: any) {
   const chromiumPath = process.env.CHROMIUM_PATH;
   const browser = await chromium.launch({
     ...(chromiumPath ? { executablePath: chromiumPath } : {}),
   });
 
-  const page = await browser.newPage();
-  await page.setViewportSize({ width: 600, height: 400 });
+  try {
+    const page = await browser.newPage();
+    await page.setViewportSize({ width: 600, height: 400 });
 
-  const html = buildTailwindScreenshotHtml(challenge.target.html);
-  await page.setContent(html, { waitUntil: 'networkidle' });
+    let fields: TailwindChallengeFields | null = null;
 
-  fs.mkdirSync(TARGETS_DIR, { recursive: true });
-  const pngPath = path.join(TARGETS_DIR, `${challenge.date}.png`);
-  await page.screenshot({ path: pngPath, type: 'png' });
-  console.log(`Saved Tailwind target PNG: ${pngPath}`);
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      const message = await client.messages.create({
+        model: 'claude-sonnet-4-6',
+        max_tokens: 4000,
+        messages,
+        system: SYSTEM_PROMPT,
+      });
 
-  await browser.close();
+      const block = message.content[0];
+      if (!block || block.type !== 'text') {
+        throw new Error(`Unexpected response content on attempt ${attempt}: ${JSON.stringify(message.content).substring(0, 200)}`);
+      }
+      const text = block.text;
+
+      let parsed: TailwindChallengeFields;
+      try {
+        parsed = extractChallenge(text);
+      } catch (err) {
+        console.warn(`Attempt ${attempt}: failed to parse response — ${(err as Error).message}`);
+        if (attempt === MAX_ATTEMPTS) throw err;
+        messages.push({ role: 'assistant', content: text });
+        messages.push({
+          role: 'user',
+          content: 'Your previous response was missing required XML tags. Output the complete challenge again with ALL of these tags: <title>, <difficulty>, <targethtml>, <starterhtml>.',
+        });
+        continue;
+      }
+
+      // Render the target and measure the component (this render is also
+      // reused for the screenshot once the size is accepted)
+      await page.setContent(buildTailwindScreenshotHtml(parsed.targetHtml), { waitUntil: 'networkidle' });
+      // Only assign fields after a successful render so fields, the rendered
+      // page, and the eventual screenshot always correspond to the same attempt.
+      fields = parsed;
+      const size = await measureComponent(page);
+
+      if (!isOversize(size)) {
+        console.log(`Attempt ${attempt}: component is ${size.width}x${size.height}px — OK`);
+        break;
+      }
+
+      console.warn(`Attempt ${attempt}: component is ${size.width}x${size.height}px (max ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT})`);
+
+      if (attempt === MAX_ATTEMPTS) {
+        // Ship it anyway — a slightly clipped challenge beats a missing day
+        console.log(`::warning::Tailwind challenge for ${date} shipped oversize at ${size.width}x${size.height}px after ${MAX_ATTEMPTS} attempts`);
+        break;
+      }
+
+      messages.push({ role: 'assistant', content: text });
+      messages.push({
+        role: 'user',
+        content: `Your component rendered at ${size.width}x${size.height}px, which exceeds the ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT}px maximum. Regenerate the challenge with a more compact layout that fits within ${MAX_COMPONENT_WIDTH}x${MAX_COMPONENT_HEIGHT}px — reduce padding, text sizes, or element count as needed. Output all the XML tags again in full.`,
+      });
+    }
+
+    if (!fields) throw new Error('Generation produced no challenge');
+
+    const challenge = {
+      title: fields.title,
+      difficulty: fields.difficulty,
+      date,
+      timeLimit: fields.difficulty === 'easy' ? 300 : fields.difficulty === 'hard' ? 900 : 600,
+      starter: { html: fields.starterHtml },
+      target: { html: fields.targetHtml },
+    };
+
+    // Save JSON
+    fs.mkdirSync(CHALLENGES_DIR, { recursive: true });
+    const jsonPath = path.join(CHALLENGES_DIR, `${date}.json`);
+    fs.writeFileSync(jsonPath, JSON.stringify(challenge, null, 2));
+    console.log(`Saved Tailwind challenge JSON: ${jsonPath}`);
+
+    // Screenshot the last rendered attempt (accepted, or shipped-anyway oversize)
+    fs.mkdirSync(TARGETS_DIR, { recursive: true });
+    const pngPath = path.join(TARGETS_DIR, `${date}.png`);
+    await page.screenshot({ path: pngPath, type: 'png' });
+    console.log(`Saved Tailwind target PNG: ${pngPath}`);
+  } finally {
+    await browser.close();
+  }
 }
 
+// CLI — defaults to tomorrow's date so the cron generates ahead of time
 const date = process.argv[2] || (() => {
   const d = new Date();
   d.setDate(d.getDate() + 1);
@@ -128,5 +189,9 @@ const date = process.argv[2] || (() => {
 })();
 
 generateChallenge(date).then(() => {
+  // Write date to stdout for CI to capture
   console.log(`CHALLENGE_DATE=${date}`);
-}).catch(console.error);
+}).catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/generate-tailwind-challenge.ts
+++ b/scripts/generate-tailwind-challenge.ts
@@ -19,7 +19,7 @@ STRICT CONSTRAINTS:
 - Use Tailwind's built-in color palette (no custom colors)
 - Focus on: flexbox, grid, spacing, borders, border-radius, typography, colors
 - NO box-shadow, text-shadow, or background-image utilities
-- NO font-family declarations (Inter font is loaded by the environment)
+- NO font-family declarations (Inter and Noto Color Emoji fonts are loaded and set by the environment)
 - The starter HTML and target HTML must have the SAME structure — only class values differ
 - Starter HTML has class="  " (two spaces) on every element — this ensures editable regions are visible in the editor
 - Target HTML has the correct Tailwind utility classes

--- a/scripts/generate-tailwind-challenge.ts
+++ b/scripts/generate-tailwind-challenge.ts
@@ -38,7 +38,7 @@ OUTPUT FORMAT — use these exact XML tags (no JSON, no code fences):
 <title>Challenge Name</title>
 <difficulty>easy|medium|hard</difficulty>
 <targethtml>The target HTML with correct Tailwind classes on every element</targethtml>
-<starterhtml>The starter HTML with class="" (empty) on every element</starterhtml>
+<starterhtml>The starter HTML with class="  " (two spaces) on every element</starterhtml>
 
 Generate creative, visually interesting components like cards, badges, buttons, navbars, pricing tables, profile cards, etc.`;
 
@@ -62,7 +62,9 @@ function extractChallenge(text: string): TailwindChallengeFields {
     title: extract('title'),
     difficulty: extract('difficulty') as 'easy' | 'medium' | 'hard',
     targetHtml: extract('targethtml'),
-    starterHtml: extract('starterhtml'),
+    // The editor needs class="  " (two spaces) so editable regions are
+    // visible; normalize any all-whitespace class value the model emits
+    starterHtml: extract('starterhtml').replace(/class="\s*"/g, 'class="  "'),
   };
 }
 

--- a/scripts/measure.ts
+++ b/scripts/measure.ts
@@ -1,0 +1,29 @@
+import type { Page } from 'playwright';
+
+export const MAX_COMPONENT_WIDTH = 520;
+export const MAX_COMPONENT_HEIGHT = 320;
+
+/**
+ * Measure the bounding box of the rendered component: the union of
+ * document.body's direct children rects (the body is a flex container
+ * that centers the component; padding/background are environment chrome).
+ */
+export async function measureComponent(page: Page): Promise<{ width: number; height: number }> {
+  return page.evaluate(() => {
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const el of Array.from(document.body.children)) {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) continue;
+      minX = Math.min(minX, r.left);
+      minY = Math.min(minY, r.top);
+      maxX = Math.max(maxX, r.right);
+      maxY = Math.max(maxY, r.bottom);
+    }
+    if (minX === Infinity) return { width: 0, height: 0 };
+    return { width: Math.round(maxX - minX), height: Math.round(maxY - minY) };
+  });
+}
+
+export function isOversize(size: { width: number; height: number }): boolean {
+  return size.width > MAX_COMPONENT_WIDTH || size.height > MAX_COMPONENT_HEIGHT;
+}

--- a/scripts/measure.ts
+++ b/scripts/measure.ts
@@ -7,6 +7,8 @@ export const MAX_COMPONENT_HEIGHT = 320;
  * Measure the bounding box of the rendered component: the union of
  * document.body's direct children rects (the body is a flex container
  * that centers the component; padding/background are environment chrome).
+ * Absolutely-positioned or transformed descendants that extend beyond a
+ * direct child's layout rect are not captured.
  */
 export async function measureComponent(page: Page): Promise<{ width: number; height: number }> {
   return page.evaluate(() => {

--- a/src/utils/code.ts
+++ b/src/utils/code.ts
@@ -1,4 +1,4 @@
-export const FONT_LINK = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap';
+export const FONT_LINK = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Color+Emoji&display=swap';
 
 export const BASE_STYLES = `
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -7,7 +7,7 @@ body {
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  font-family: 'Inter', sans-serif;
+  font-family: 'Inter', 'Noto Color Emoji', sans-serif;
   background: #f5f5f5;
   padding: 20px;
 }
@@ -51,7 +51,7 @@ export function buildTailwindSrcdoc(html: string): string {
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="${FONT_LINK}">
 </head>
-<body class="bg-[#f5f5f5] min-h-screen flex items-center justify-center p-5 font-['Inter']">
+<body class="bg-[#f5f5f5] min-h-screen flex items-center justify-center p-5 font-['Inter','Noto_Color_Emoji']">
 ${sanitizedHtml}
 </body>
 </html>`;

--- a/src/utils/code.ts
+++ b/src/utils/code.ts
@@ -50,8 +50,9 @@ export function buildTailwindSrcdoc(html: string): string {
   <meta charset="UTF-8">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="${FONT_LINK}">
+  <style>body { font-family: 'Inter', 'Noto Color Emoji', sans-serif; }</style>
 </head>
-<body class="bg-[#f5f5f5] min-h-screen flex items-center justify-center p-5 font-['Inter','Noto_Color_Emoji']">
+<body class="bg-[#f5f5f5] min-h-screen flex items-center justify-center p-5">
 ${sanitizedHtml}
 </body>
 </html>`;


### PR DESCRIPTION
- Noto Color Emoji pinned in all rendering paths (with a more robust <style> block for the
  Tailwind path after review caught a CDN JIT risk)
- Shared Playwright measurement helper, fixture-tested
- Both generators restructured into measure-and-retry loops with review-hardening: guarded API
  responses, retryable parse failures, JSON↔screenshot consistency invariant, and nonzero exit
  codes so CI no longer reports success on failed generation (a pre-existing bug we found along the
  way)