### PR TITLE
Move difficulty switcher into the header control cluster, themed to match

### DIFF
--- a/src/components/ChallengePlayer.tsx
+++ b/src/components/ChallengePlayer.tsx
@@ -205,9 +205,7 @@ export default function ChallengePlayer({ challenge, allDates, availableDifficul
 
           <div className="flex items-center gap-4">
             <span className="text-sm text-gray-400">{challenge.title}</span>
-            {multi ? (
-              <DifficultySwitcher available={availableDifficulties} />
-            ) : (
+            {!multi && (
               <span className={`text-xs px-2 py-0.5 rounded ${challenge.difficulty === 'easy' ? 'bg-green-900 text-green-300' :
                 challenge.difficulty === 'medium' ? 'bg-yellow-900 text-yellow-300' :
                   'bg-red-900 text-red-300'
@@ -244,6 +242,11 @@ export default function ChallengePlayer({ challenge, allDates, availableDifficul
                 Results
               </button>
             )}
+            {/* Placed left of the constant-width Layout/Stats buttons: the
+                cluster is right-anchored, so the switcher's position is
+                immune to timer/score/phase-button width changes — a stable
+                click target when rapidly cycling difficulties */}
+            {multi && <DifficultySwitcher available={availableDifficulties} />}
             <LayoutToggle />
             <button
               onClick={() => setShowHistory(true)}

--- a/src/components/DifficultySwitcher.tsx
+++ b/src/components/DifficultySwitcher.tsx
@@ -7,13 +7,16 @@ interface DifficultySwitcherProps {
 }
 
 // Visual active state is CSS-only (driven by <html data-difficulty>, stamped
-// pre-paint) so it never flashes. The hover literals lock the active color at
-// higher specificity than `hover:text-white`, independent of stylesheet order.
+// pre-paint) so it never flashes. The hover literals lock the active color
+// and background at higher specificity than the base hover utilities,
+// independent of stylesheet order.
 const ACTIVE_CLASSES: Record<Difficulty, string> = {
-  easy: '[[data-difficulty=easy]_&]:bg-green-900 [[data-difficulty=easy]_&]:text-green-300 [[data-difficulty=easy]_&]:hover:text-green-300',
-  medium: '[[data-difficulty=medium]_&]:bg-yellow-900 [[data-difficulty=medium]_&]:text-yellow-300 [[data-difficulty=medium]_&]:hover:text-yellow-300',
-  hard: '[[data-difficulty=hard]_&]:bg-red-900 [[data-difficulty=hard]_&]:text-red-300 [[data-difficulty=hard]_&]:hover:text-red-300',
+  easy: '[[data-difficulty=easy]_&]:bg-green-900 [[data-difficulty=easy]_&]:text-green-300 [[data-difficulty=easy]_&]:hover:bg-green-900 [[data-difficulty=easy]_&]:hover:text-green-300',
+  medium: '[[data-difficulty=medium]_&]:bg-yellow-900 [[data-difficulty=medium]_&]:text-yellow-300 [[data-difficulty=medium]_&]:hover:bg-yellow-900 [[data-difficulty=medium]_&]:hover:text-yellow-300',
+  hard: '[[data-difficulty=hard]_&]:bg-red-900 [[data-difficulty=hard]_&]:text-red-300 [[data-difficulty=hard]_&]:hover:bg-red-900 [[data-difficulty=hard]_&]:hover:text-red-300',
 };
+
+const LABELS: Record<Difficulty, string> = { easy: 'E', medium: 'M', hard: 'H' };
 
 export default function DifficultySwitcher({ available }: DifficultySwitcherProps) {
   // aria-pressed needs real state for screen readers; hydrated post-mount so
@@ -38,16 +41,20 @@ export default function DifficultySwitcher({ available }: DifficultySwitcherProp
   };
 
   return (
-    <div className="flex text-xs rounded overflow-hidden border border-gray-700" role="group" aria-label="Difficulty">
+    // Themed like the neighboring control buttons (h-8, gray-700 base);
+    // single letters keep the cluster compact — full names go to aria/title
+    <div className="flex h-8 rounded-lg overflow-hidden divide-x divide-gray-800" role="group" aria-label="Difficulty">
       {DIFFICULTY_ORDER.filter((d) => available.includes(d)).map((d) => (
         <button
           key={d}
           type="button"
           onClick={() => select(d)}
           aria-pressed={selected === d}
-          className={`px-2 py-0.5 capitalize text-gray-500 hover:text-white ${ACTIVE_CLASSES[d]}`}
+          aria-label={d}
+          title={d.charAt(0).toUpperCase() + d.slice(1)}
+          className={`px-2.5 text-sm font-medium inline-flex items-center bg-gray-700 hover:bg-gray-600 text-gray-400 hover:text-white ${ACTIVE_CLASSES[d]}`}
         >
-          {d}
+          {LABELS[d]}
         </button>
       ))}
     </div>

--- a/src/components/LayoutToggle.tsx
+++ b/src/components/LayoutToggle.tsx
@@ -20,7 +20,10 @@ export default function LayoutToggle() {
       onClick={toggle}
       title="Toggle layout"
       aria-label="Toggle layout"
-      className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white text-sm inline-flex items-center rounded-lg transition"
+      // h-8 matches the text buttons' rendered height (text-sm line + py-1.5):
+      // an icon-only flex button generates no text line box, so without an
+      // explicit height it collapses to the 16px icon and sits shorter
+      className="px-3 h-8 bg-gray-700 hover:bg-gray-600 text-white inline-flex items-center rounded-lg transition"
     >
       {/* Each icon previews the layout clicking switches to; CSS swaps them */}
       <svg className="[[data-layout=columns]_&]:hidden" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">

--- a/src/components/TailwindPlayer.tsx
+++ b/src/components/TailwindPlayer.tsx
@@ -206,9 +206,7 @@ export default function TailwindPlayer({ challenge, allDates, availableDifficult
 
           <div className="flex items-center gap-4">
             <span className="text-sm text-gray-400">{challenge.title}</span>
-            {multi ? (
-              <DifficultySwitcher available={availableDifficulties} />
-            ) : (
+            {!multi && (
               <span className={`text-xs px-2 py-0.5 rounded ${challenge.difficulty === 'easy' ? 'bg-green-900 text-green-300' :
                 challenge.difficulty === 'medium' ? 'bg-yellow-900 text-yellow-300' :
                   'bg-red-900 text-red-300'
@@ -245,6 +243,11 @@ export default function TailwindPlayer({ challenge, allDates, availableDifficult
                 Results
               </button>
             )}
+            {/* Placed left of the constant-width Layout/Stats buttons: the
+                cluster is right-anchored, so the switcher's position is
+                immune to timer/score/phase-button width changes — a stable
+                click target when rapidly cycling difficulties */}
+            {multi && <DifficultySwitcher available={availableDifficulties} />}
             <LayoutToggle />
             <button
               onClick={() => setShowHistory(true)}


### PR DESCRIPTION
The switcher previously sat next to the centered title, so its position shifted with title length when cycling difficulties — a moving click target. It now lives in the right-anchored control cluster, left of the constant-width Layout/Stats buttons, making its position immune to title, timer, score, and phase-button width changes (verified pixel- identical across difficulties and phases at 1440px).

Restyled to match its neighbors: h-8 segmented E/M/H buttons on the gray-700 base, active difficulty keeping its color (locked against hover at higher specificity); full difficulty names exposed via aria-label/title. Titles render untruncated again; legacy pages keep their badge by the title. LayoutToggle gets an explicit h-8 — icon-only flex buttons generate no text line box, so it rendered 4px shorter than Stats.